### PR TITLE
Fix blog post header

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="home">
 
-  <h1 class="page-heading">Posts</h1>
+  <h1 class="page-heading">Blog</h1>
 
   {{ content }}
 


### PR DESCRIPTION
Change header to "Blog" instead of "Posts".